### PR TITLE
Update image sources to use icr.io images

### DIFF
--- a/jpetstore/Dockerfile
+++ b/jpetstore/Dockerfile
@@ -1,12 +1,12 @@
 # Build JPetStore war
-FROM ibm-semeru-runtimes:open-8-jdk as builder
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-focal as builder
 COPY . /src
 WORKDIR /src
 RUN ./build.sh all
 
 # Use WebSphere Liberty base image from the Docker Store
 # FROM websphere-liberty:javaee7
-FROM docker.io/ibmcom/websphere-liberty:21.0.0.12-full-java8-ibmjava-ubi
+FROM icr.io/appcafe/websphere-liberty:full-java8-ibmjava-ubi
 
 # Copy war from build stage and server.xml into image
 COPY --from=builder /src/dist/jpetstore.war /opt/ibm/wlp/usr/servers/defaultServer/apps/
@@ -14,3 +14,4 @@ COPY --from=builder /src/server.xml /opt/ibm/wlp/usr/servers/defaultServer/
 RUN mkdir -p /config/lib/global
 COPY lib/mysql-connector-java-3.0.17-ga-bin.jar /config/lib/global
 COPY lib/postgresql-42.5.1.jar /config/lib/global
+


### PR DESCRIPTION
Last week the original pipeline built petstore was updated to use images from `icr.io` rather than Dockerhub. I have added those changes to the Dockerfile here but I'm not sure which source would be more accessible for most users.