### PR TITLE
Add resources for single cluster, multiarch builds

### DIFF
--- a/petstore-pipelines-files/multiarch-cluster-build/README.md
+++ b/petstore-pipelines-files/multiarch-cluster-build/README.md
@@ -1,0 +1,4 @@
+# multiarch-cluster-build
+The pipeline files in this directory are an alternative to my previously presented method (available [here](https://ibm.biz/BdyaPz)) for completing multiarch native builds in OpenShift. Rather than using multiple clusters, this method is designed for a single multi-arch cluster. Support for a multiarch cluster was added to OCP 4.14 (docs [here](https://docs.openshift.com/container-platform/4.14/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.html)).
+See [my experience report]() where I describe setting up a multiarch cluster on KVM with x86 managers and both x86 and s390x workers. 
+I also have [an experience report]() where I include more details of setting up a multiarch OCP cluster on KVM with x86 managers and s390x workers.

--- a/petstore-pipelines-files/multiarch-cluster-build/assemble-manifest.yaml
+++ b/petstore-pipelines-files/multiarch-cluster-build/assemble-manifest.yaml
@@ -1,0 +1,52 @@
+# modified from https://github.com/OpenShift-Z/ocp-pipelines/blob/main/shared-pipeline-resources/assemble-manifest-task.yaml
+# Changes:
+#    - Use latest buildah image (meant for proxied/connected cluster)
+#    - Remove image registry creds workspaces since using internal image registry
+# see the associated experience report for more details:
+# 
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  name: assemble-manifest
+spec:
+  params:
+    - description: Full manifest name including the registry and tag
+      name: manifest-name
+      type: string
+    - description: 'Full image name without tag, all images should use the same base name'
+      name: image-name
+      type: string
+    - description: comma separated list of tags to include in the manifest
+      name: tags
+      type: string
+  steps:
+    - image: 'registry.redhat.io/rhel8/buildah:latest'
+      name: create-manifest
+      resources: {}
+      script: >
+        #!/bin/bash 
+
+        set -x
+
+        tmpName="tmp-manifest:latest"
+
+        buildah manifest create "$tmpName"
+
+        tags="$(params.tags)"
+
+        for i in ${tags//,/ }
+
+        do
+
+          buildah manifest add "$tmpName" $(params.image-name):$i --tls-verify=false
+
+        done
+
+        buildah manifest inspect "$tmpName"
+
+        buildah manifest push $tmpName "docker://$(params.manifest-name)"
+        --tls-verify=false --all
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP

--- a/petstore-pipelines-files/multiarch-cluster-build/multiarch-petstore-build-and-deploy.yaml
+++ b/petstore-pipelines-files/multiarch-cluster-build/multiarch-petstore-build-and-deploy.yaml
@@ -1,0 +1,129 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: multiarch-petstore-build-and-deploy
+  namespace: petstore
+spec:
+  params:
+    - default: petstore
+      name: deployment-name
+      type: string
+    - default: 'https://github.com/OpenShift-Z/petstore.git'
+      description: url of the git repo for petstore deployment
+      name: git-url
+      type: string
+    - default: main
+      description: revision of the git repo to be deployed
+      name: git-revision
+      type: string
+    - default: jpetstore/
+      description: Context directory for buildah to use (appended to /workspace/source/)
+      name: buildah-context
+      type: string
+    - default: ./Dockerfile
+      description: path to dockerfile for buildah to use relative to the context directory
+      name: dockerfile-path
+      type: string
+    - default: 'image-registry.openshift-image-registry.svc:5000'
+      description: where should the multi-arch manifest be pushed
+      name: dest-registry
+      type: string
+  tasks:
+    - name: fetch-repository
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.git-revision)
+        - name: deleteExisting
+          value: 'true'
+      taskRef:
+        kind: ClusterTask
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-ws
+    - name: s390x-build
+      params:
+        - name: IMAGE
+          value: >-
+            image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(params.deployment-name):s390x
+        - name: CONTEXT
+          value: /workspace/source/$(params.buildah-context)
+        - name: DOCKERFILE
+          value: $(params.dockerfile-path)
+        - name: FORMAT
+          value: docker
+        - name: SKIP_PUSH
+          value: 'false'
+      runAfter:
+        - fetch-repository
+      taskRef:
+        kind: ClusterTask
+        name: buildah
+      workspaces:
+        - name: source
+          workspace: shared-ws
+    - name: x86-build
+      params:
+        - name: IMAGE
+          value: >-
+            image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(params.deployment-name):x86
+        - name: CONTEXT
+          value: /workspace/source/$(params.buildah-context)
+        - name: DOCKERFILE
+          value: $(params.dockerfile-path)
+        - name: FORMAT
+          value: docker
+        - name: SKIP_PUSH
+          value: 'false'
+      runAfter:
+        - fetch-repository
+      taskRef:
+        kind: ClusterTask
+        name: buildah
+      workspaces:
+        - name: source
+          workspace: shared-ws
+    - name: assemble-manifest
+      params:
+        - name: manifest-name
+          value: >-
+            $(params.dest-registry)/$(context.pipelineRun.namespace)/$(params.deployment-name):latest
+        - name: image-name
+          value: >-
+            image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(params.deployment-name)
+        - name: tags
+          value: 'x86,s390x'
+      runAfter:
+        - s390x-build
+        - x86-build
+      taskRef:
+        kind: ClusterTask
+        name: assemble-manifest
+    - name: create-deployment
+      params:
+        - name: SCRIPT
+          value: >
+            oc new-app --image
+            $(params.dest-registry)/$(context.pipelineRun.namespace)/$(params.deployment-name):latest
+            -n $(context.pipelineRun.namespace) --name $(params.deployment-name)
+            --import-mode=PreserveOriginal
+      runAfter:
+        - assemble-manifest
+      taskRef:
+        kind: ClusterTask
+        name: openshift-client
+    - name: expose-service
+      params:
+        - name: SCRIPT
+          value: >
+            oc expose service/$(params.deployment-name)-x86 -n
+            $(context.pipelineRun.namespace) || true
+      runAfter:
+        - create-deployment
+      taskRef:
+        kind: ClusterTask
+        name: openshift-client
+  workspaces:
+    - name: shared-ws

--- a/petstore-pipelines-files/multiarch-cluster-build/multiarch-pipelinerun.yaml
+++ b/petstore-pipelines-files/multiarch-cluster-build/multiarch-pipelinerun.yaml
@@ -1,0 +1,51 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: build-and-deploy-petstore-egtj33
+  namespace: petstore
+spec:
+  params:
+    - name: deployment-name
+      value: petstore
+    - name: git-url
+      value: 'https://github.com/OpenShift-Z/petstore.git'
+    - name: git-revision
+      value: main
+    - name: buildah-context
+      value: jpetstore/
+    - name: dockerfile-path
+      value: ./Dockerfile
+    - name: dest-registry
+      value: 'image-registry.openshift-image-registry.svc:5000'
+  pipelineRef:
+    name: multiarch-petstore-build-and-deploy
+  taskRunSpecs:
+    - pipelineTaskName: s390x-build
+      podTemplate:
+        nodeSelector:
+          kubernetes.io/arch: s390x
+    # note here that we use `amd64` since this is what OCP uses
+    # if no nodes match the specified arch, the task will be stuck
+    # at pending
+    - pipelineTaskName: x86-build
+      podTemplate:
+        nodeSelector:
+          kubernetes.io/arch: amd64
+  taskRunTemplate:
+    serviceAccountName: pipeline
+  timeouts:
+    pipeline: 1h0m0s
+  workspaces:
+    - name: shared-ws
+      volumeClaimTemplate:
+        metadata:
+          creationTimestamp: null
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+          storageClassName: ocs-storagecluster-cephfs
+          volumeMode: Filesystem
+        status: {}


### PR DESCRIPTION
OCP 4.14 added support for adding s390x worker nodes to an x86 OCP cluster. The files in this commit make use of an OCP 4.14 cluster with s390x and x86 workers to build a multi-arch "fat" manifest using a single OpenShift (Tekton) pipeline. Experience reports will be added to the [HCIT blogs page](https://community.ibm.com/community/user/ibmz-and-linuxone/groups/community-home/librarydocuments?communitykey=2a2f855c-5950-4a9d-8485-86645982646a&LibraryFolderKey=&DefaultView=) this Friday with a better explanation of the process.